### PR TITLE
Fix for serialization issue of embeddedlist documents

### DIFF
--- a/pyorient/serializations.py
+++ b/pyorient/serializations.py
@@ -475,7 +475,7 @@ class OrientSerializationCSV(object):
             key = chunk[0]
             content = chunk[1]
 
-        chunk = self._parse_key(content)
+        chunk = self._parse_value(content)
         value = chunk[0]
         content = chunk[1].lstrip(' ')
 


### PR DESCRIPTION
This is my first pull request on Github, so my apologies if any information is missing...

I ran into a bug when returning an embeddedlist of a document class from the client.command() function. If the first entry of the embedded document class is not a string, then the key/value pairs in the dictionary would be wrong. I stepped through the code to the serialization.py file. When returning the item, the first key is fetched as part of an if clause. Either route through the 'if' will result in getting the first key. After exiting the 'if', the next line (478) also tries to get a key (_parse_key(content)). If the value is a string then it is fine because parse key checks for : or ". If it is another type, e.g., a double or a float, then the parsing carries on until after the next key. This then causes some subsequent key/value fetches to be out of sync too. I changed the code so that instead of getting a key, and then another key, it now gets a key and then a value.