### PR TITLE
Partial revert of a6656ae - fix for OGM vertex generation

### DIFF
--- a/pyorient/ogm/graph.py
+++ b/pyorient/ogm/graph.py
@@ -529,7 +529,7 @@ class Graph(object):
             self.drop_class(cls, ignore_instances=True)
 
     def create_vertex(self, vertex_cls, **kwargs):
-        result = self.client.command(self.create_vertex_command(vertex_cls, **kwargs))[0]
+        result = self.client.command(to_unicode(self.create_vertex_command(vertex_cls, **kwargs)))[0]
 
         props = result.oRecordData
         return vertex_cls.from_graph(self, result._rid, self.props_from_db[vertex_cls](props))


### PR DESCRIPTION
We have found in our usage that vertex creation through the OGM has been broken by the previous commit. Adding back the to_unicode wrap to the client command call fixes this.